### PR TITLE
Cleanup feed flow and check profile page children initialization

### DIFF
--- a/js/components/CategoryPage.jsx
+++ b/js/components/CategoryPage.jsx
@@ -21,7 +21,7 @@ var CategoryPage = React.createClass({
         <div className="row categoryPageHeader">
           <Toolbar />
         </div>
-        <div className="col-md-6 col-md-offset-3"><Feed category={this.props.params.category}/></div>
+        <div className="col-md-6 col-md-offset-3"><Feed category={this.props.params.category} parent="CategoryPage" /></div>
         <div className="row">
           <div className="row categoryPageFooter">
             <Footer />

--- a/js/components/Feed.jsx
+++ b/js/components/Feed.jsx
@@ -12,27 +12,29 @@ var Feed = React.createClass({
   },
 
   componentDidMount: function() {
-    this.setTransactions(this.props.userId, this.props.category, this.props.filter); 
+    this.setTransactions(); 
   },
 
-  setTransactions: function(userId, category, filter) {
-    // TODO : paginations
+  generateUrl: function() {
     var url;
-
-    // TODO : Come up with a better flow for determing feed data
-    if (!userId && !category) {
+    if (this.props.parent === "ProfilePage") {
+      url = '/api/transactions/users/' + this.props.userId + '/' + this.state.filter + '/public';
+    } else if (this.props.parent === "HomePage") {
       url = '/api/transactions';
-    } else if (category) {
-      url = '/api/transactions/categories/' + category;
-    } else if (userId) {
-      url = '/api/transactions/users/' + userId + '/' + filter + '/public';
+    } else if (this.props.parent === "CategoryPage") {
+      url = '/api/transactions/categories/' + this.props.category;
     }
+    return url;
+  },
 
+  setTransactions: function() {
+    var url = this.generateUrl();
+    // TODO : paginations
     $.ajax({
       url: url,
       dataType: 'json',
       success: function(transactions) {
-        this.setState({ transactions : transactions, filter: filter });
+        this.setState({ transactions : transactions });
       }.bind(this),
       error: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
@@ -41,12 +43,15 @@ var Feed = React.createClass({
   },
 
   componentWillReceiveProps: function(newProps) {
-    this.setTransactions(newProps.userId, newProps.category, newProps.filter);
+    this.setState({ filter: newProps.filter });
+  },
+
+  componentWillUpdate: function() {
+    this.setTransactions();
   },
 
   handleClick: function(newFilter) {
     this.setState({ filter: newFilter });
-    this.setTransactions(this.props.userId, this.props.category, newFilter);
   },
 
   render: function() {

--- a/js/components/HomePage.jsx
+++ b/js/components/HomePage.jsx
@@ -14,7 +14,7 @@ var HomePage = React.createClass({
     return (
       <div className="homePage">
         <Toolbar />
-        <div className="col-md-8 col-md-offset-2"><Feed /></div>
+        <div className="col-md-8 col-md-offset-2"><Feed parent="HomePage" /></div>
         <Footer />
       </div>
     );

--- a/js/components/ProfilePage.jsx
+++ b/js/components/ProfilePage.jsx
@@ -17,7 +17,7 @@ var ProfilePage = React.createClass({
   mixins: [AuthenticatedRoute],
 
   getInitialState: function() {
-    return { user: { categories: [], links: [], username: '' } };
+    return {};
   },
 
   updateUser: function() {
@@ -46,8 +46,11 @@ var ProfilePage = React.createClass({
   },
 
   render: function() {
-    var feed = this.state.user._id ? <Feed userId={this.state.user._id} filter={"all"} /> : '';
-    var portfolio = this.state.user._id ? <PortfolioTable user={this.state.user} /> : '';
+    var feed = this.state.user ? <Feed parent="ProfilePage" userId={this.state.user._id} filter={"all"} /> : '';
+    var portfolio = this.state.user ? <PortfolioTable user={this.state.user} /> : '';
+    var categoriesTable = this.state.user ? <CategoriesTable categories={this.state.user.categories} /> : '';
+    var donationBox = this.state.user ? <DonationBox user={this.state.user} /> : '';
+    var profileBox = this.state.user ? <ProfileBox user={this.state.user} /> : '';
     return (
       <div className="profilePage container-fluid">
         <div id="header">
@@ -55,7 +58,7 @@ var ProfilePage = React.createClass({
         </div>
         <div id="content">
           <div className="row">
-            <ProfileBox user={this.state.user} />
+            {profileBox}
           </div>
           <div className="row">
             <div className="col-md-5">
@@ -63,9 +66,13 @@ var ProfilePage = React.createClass({
             </div>
           </div>
           <div className="row">
-            <div className="col-md-4 profilePageCategoriesTable"><CategoriesTable categories={this.state.user.categories} /></div>
+            <div className="col-md-4 profilePageCategoriesTable">
+              {categoriesTable}
+            </div>
             <div className="col-md-7 profilePageFeed">
-              <div className="profileDonationBox"><DonationBox user={this.state.user} /></div>
+              <div className="profileDonationBox">
+                {donationBox}
+              </div>
             {feed}
             </div>
           </div>


### PR DESCRIPTION
Significant reduction of complexity.

ProfilePage will not call any of its children unless the user is available. This will prevent any of its children from having to check for their props. It will also mean that this.state.user is the consistent check for all child components from now on, which is an easy pattern.

Feed now has a nice flow, since it has a parent flag. It may be possible to dynamically determine the class of the parent component, which I'm waiting on with a StackOverflow post (http://stackoverflow.com/questions/26541400/can-you-dynamically-get-parent-component-classname-in-reactjs)

Feed also no longer passes parameters to setTransactions(). This reduces complexity. To counteract the asynchronous nature of setState(), rather than passing the new filter state to setTransactions(), we can just call componentWillUpdate(), which will only act after setState() has occurred.
