### PR TITLE
Fix invariant violation error with unique key

### DIFF
--- a/js/components/CategoriesItem.jsx
+++ b/js/components/CategoriesItem.jsx
@@ -5,14 +5,9 @@ var React = require('react');
 var ScoreBar = require('./ScoreBar.jsx');
 
 var CategoriesItem = React.createClass({
-  getDefaultProps: function() {
-    return {
-      reps: -1
-    };
-  },
-
   render: function() {
-    var reps = this.props.reps >= 0 ? <td>{this.props.reps}</td> : '';
+    var reps = this.props.includeReps ? <td>{this.props.reps}</td> : '';
+
     return (
       <tr className="categoriesItem">
         <td>{this.props.category}</td>

--- a/js/components/CategoriesTable.jsx
+++ b/js/components/CategoriesTable.jsx
@@ -9,31 +9,27 @@ var $ = require('jquery');
 
 var CategoriesTable = React.createClass({
   render: function() {
-    var toIncludeReps = false;
+    var includeReps = false;
     var repsHeader = '';
     if (this.props.currentUser.username === this.props.user.username) {
-        toIncludeReps = true;
+        includeReps = true;
         repsHeader = <th>Reps</th>;
     }
 
     return (
-      <div className="categoriesTable panel panel-default">
+      <div key={this.props.user._id} className="categoriesTable panel panel-default">
         <CategoriesHeader user={this.props.user} />
         <table className="table table-bordered table-striped">
-          <tr>
-            <th>Category</th>
-            <th>Direct Rep</th>
-            <th>Crowd Rep</th>
-            {repsHeader}
-          </tr>
           <tbody>
-          {this.props.user.categories.map(function(category) {
-            if (toIncludeReps) {
-              return <CategoriesItem key={category.id} category={category.name} directRep={category.directScore} prevDirectRep={category.previousDirectScore} crowdRep={category.crowdScore} reps={category.reps} />;
-            } else {
-              return <CategoriesItem key={category.id} category={category.name} directRep={category.directScore} prevDirectRep={category.previousDirectScore} crowdRep={category.crowdScore} />;
-            }
-          })}
+            <tr>
+              <th>Category</th>
+              <th>Direct Rep</th>
+              <th>Crowd Rep</th>
+              {repsHeader}
+            </tr>
+            {this.props.user.categories.map(function(category) {
+              return <CategoriesItem key={category.id} category={category.name} directRep={category.directScore} prevDirectRep={category.previousDirectScore} crowdRep={category.crowdScore} reps={category.reps} includeReps={includeReps} />;
+            })}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
React tables cannot handle when you dynamically change the columns in the table. This is because React tries to only re-render parts of a component that have changed, which gets all wonky with tables. Fortunately, React components can be given a key id. If the key changes, then the entire component is re-rendered. Giving the CategoriesTable a unique key for the id of the user's profile page makes this go away!
