### PR TITLE
Remove all routes except for anticipation page

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -774,3 +774,11 @@ textarea {
 .error-page {
   text-align: center;
 }
+
+/* Anticipation Page */
+.anticipation-text {
+  text-align: center;
+  font-size: 26px;
+  position: absolute;
+  top: 45%; left: 0; bottom: 0; right: 0;
+}

--- a/js/app.jsx
+++ b/js/app.jsx
@@ -2,6 +2,7 @@
 
 var $ = require('jquery');
 var AboutPage = require('./components/AboutPage.jsx');
+var AnticipationPage = require('./components/AnticipationPage.jsx');
 var auth = require('./auth.jsx');
 var ContactUsPage = require('./components/ContactUsPage.jsx');
 var CategoriesPage = require('./components/CategoriesPage.jsx');
@@ -67,19 +68,7 @@ var RepsApp = React.createClass({
 
 var routes = (
   <Route handler={RepsApp}>
-    <DefaultRoute handler={LoginPage} />
-    <Route name="about" handler={AboutPage} />
-    <Route name="categories" handler={CategoriesPage} />
-    <Route name="category" path="/categories/:category" handler={CategoryPage}/>
-    <Route name="contactUs" handler={ContactUsPage} />
-    <Route name="home" handler={HomePage} />
-    <Route name="login" handler={LoginPage} />
-    <Route name="profile" path="/user/:userId" handler={ProfilePage}/>
-    <Route name="search" path="/search/:query" handler={SearchPage}/>
-    <Route name="passwordReset" path="/passwordReset/:token" handler={PasswordResetPage} />
-    <Route name="team" handler={TeamPage} />
-    <Route name="verification" path="/verify/:token/" handler={VerificationPage} />
-    <Route name="categoryRequest" path="/categoryRequest/:userId/:categoryName/:action/:expert" handler={CategoryRequestPage} />
+    <DefaultRoute handler={AnticipationPage} />
   </Route>
 );
 Router.run(routes, function (Handler, state) {

--- a/js/components/AnticipationPage.jsx
+++ b/js/components/AnticipationPage.jsx
@@ -1,0 +1,16 @@
+'use strict';
+var React = require('react');
+
+var AnticipationPage = React.createClass({
+  render: function() {
+    return (
+      <div className="anticipation-text">
+        <span >
+          Repcoin will be available for use this Thursday, February 12th.
+        </span>
+      </div>
+    );
+  },
+});
+
+module.exports = AnticipationPage;


### PR DESCRIPTION
My thoughts are as follows, we push this to heroku, then revert it but don't push to Heroku until we're ready for the beta. Thoughts?