### PR TITLE
Validate email address

### DIFF
--- a/api/routes/utils.js
+++ b/api/routes/utils.js
@@ -246,6 +246,11 @@ var utils = {
         !req.body.email) {
       return false;
     }
+
+    var reg = new RegExp("[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?");
+    if (!reg.test(req.body.email)) {
+      return false;
+    }
     return true;
   },
 


### PR DESCRIPTION
Fixes #624

Regex comes from this page:

http://stackoverflow.com/questions/46155/validate-email-address-in-javascript

This allegedly works on almost every address. It should certainly not deny any of the ones from our users, who are pretty mainstream